### PR TITLE
Wayne Manion: Added support for multiple ADXL345 sensors on i2c bus

### DIFF
--- a/Adafruit_ADXL345_U.cpp
+++ b/Adafruit_ADXL345_U.cpp
@@ -82,7 +82,7 @@ static uint8_t spixfer(uint8_t clock, uint8_t miso, uint8_t mosi, uint8_t data) 
 /**************************************************************************/
 void Adafruit_ADXL345_Unified::writeRegister(uint8_t reg, uint8_t value) {
   if (_i2c) {
-    Wire.beginTransmission(ADXL345_ADDRESS);
+    Wire.beginTransmission((uint8_t)_i2caddr);
     i2cwrite((uint8_t)reg);
     i2cwrite((uint8_t)(value));
     Wire.endTransmission();
@@ -101,10 +101,10 @@ void Adafruit_ADXL345_Unified::writeRegister(uint8_t reg, uint8_t value) {
 /**************************************************************************/
 uint8_t Adafruit_ADXL345_Unified::readRegister(uint8_t reg) {
   if (_i2c) {
-    Wire.beginTransmission(ADXL345_ADDRESS);
+    Wire.beginTransmission((uint8_t)_i2caddr);
     i2cwrite(reg);
     Wire.endTransmission();
-    Wire.requestFrom(ADXL345_ADDRESS, 1);
+    Wire.requestFrom((uint8_t)_i2caddr, 1);
     return (i2cread());
   } else {
     reg |= 0x80; // read byte
@@ -123,10 +123,10 @@ uint8_t Adafruit_ADXL345_Unified::readRegister(uint8_t reg) {
 /**************************************************************************/
 int16_t Adafruit_ADXL345_Unified::read16(uint8_t reg) {
   if (_i2c) {
-    Wire.beginTransmission(ADXL345_ADDRESS);
+    Wire.beginTransmission((uint8_t)_i2caddr);
     i2cwrite(reg);
     Wire.endTransmission();
-    Wire.requestFrom(ADXL345_ADDRESS, 2);
+    Wire.requestFrom((uint8_t)_i2caddr, 2);
     return (uint16_t)(i2cread() | (i2cread() << 8));  
   } else {
     reg |= 0x80 | 0x40; // read byte | multibyte
@@ -206,7 +206,8 @@ Adafruit_ADXL345_Unified::Adafruit_ADXL345_Unified(uint8_t clock, uint8_t miso, 
     @brief  Setups the HW (reads coefficients values, etc.)
 */
 /**************************************************************************/
-bool Adafruit_ADXL345_Unified::begin() {
+bool Adafruit_ADXL345_Unified::begin(uint8_t i2caddr) {
+  _i2caddr = i2caddr;
   
   if (_i2c)
     Wire.begin();

--- a/Adafruit_ADXL345_U.h
+++ b/Adafruit_ADXL345_U.h
@@ -29,7 +29,7 @@
 /*=========================================================================
     I2C ADDRESS/BITS
     -----------------------------------------------------------------------*/
-    #define ADXL345_ADDRESS                 (0x53)    // Assumes ALT address pin low
+    #define ADXL345_DEFAULT_ADDRESS     (0x53)  // Assumes ALT address pin low
 /*=========================================================================*/
 
 /*=========================================================================
@@ -108,7 +108,7 @@ class Adafruit_ADXL345_Unified : public Adafruit_Sensor {
   Adafruit_ADXL345_Unified(int32_t sensorID = -1);
   Adafruit_ADXL345_Unified(uint8_t clock, uint8_t miso, uint8_t mosi, uint8_t cs, int32_t sensorID = -1);
 
-  bool       begin(void);
+  bool       begin(uint8_t addr = ADXL345_DEFAULT_ADDRESS);
   void       setRange(range_t range);
   range_t    getRange(void);
   void       setDataRate(dataRate_t dataRate);
@@ -131,4 +131,5 @@ class Adafruit_ADXL345_Unified : public Adafruit_Sensor {
   range_t _range;
   uint8_t _clk, _do, _di, _cs;
   bool    _i2c;
+  int8_t  _i2caddr;
 };


### PR DESCRIPTION
My project requires two ADXL345 sensors. The library only supports one sensor as written. I looked at the source code for the ADXL345 library and the LIS3DH library and modified the ADXL345 library to match the way that the LIS3DH handles parameters in the begin() method. 

I have tested this in my project with two ADXL345 sensors and it works. One unit has the SDO pin held high, giving it the 0x1D address. The other ADXL345's SDO pin is not connected to anything, so its address is the default 0x53. I can then create two different ADXL345 Objects and send the appropriate address to the begin() method for each Object. It works great. 

Thanks
Wayne Manion