### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_ADXL345_U.h
+++ b/Adafruit_ADXL345_U.h
@@ -33,8 +33,9 @@
 #include "WProgram.h"
 #endif
 
+#include <Adafruit_I2CDevice.h>
+#include <Adafruit_SPIDevice.h>
 #include <Adafruit_Sensor.h>
-#include <Wire.h>
 
 /*=========================================================================
     I2C ADDRESS/BITS
@@ -145,14 +146,11 @@ public:
   int16_t getX(void), getY(void), getZ(void);
 
 private:
-  inline uint8_t i2cread(void);
-  inline void i2cwrite(uint8_t x);
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
+  Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
 
   int32_t _sensorID;
   range_t _range;
-  uint8_t _clk, _do, _di, _cs;
-  bool _i2c;
-  int8_t _i2caddr;
 };
 
 #endif // Adafruit_ADXL345_h

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit ADXL345
-version=1.2.2
+version=1.3.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Unified driver for the ADXL345 Accelerometer
@@ -7,4 +7,4 @@ paragraph=Unified driver for the ADXL345 Accelerometer
 category=Sensors
 url=https://github.com/adafruit/Adafruit_ADXL345
 architectures=*
-depends=Adafruit Unified Sensor
+depends=Adafruit Unified Sensor, Adafruit BusIO


### PR DESCRIPTION
For #23. Only converts to BusIO usage without changing any of existing API, which has some limitations:
* no hardware spi
* no alternate i2c bus

Tested with Qt PY using `sensortest` example from library using I2C and SPI. Had to add SPI setup to sketch:
```cpp
#define CS_PIN 2
#define SCK_PIN 5
#define MOSI_PIN  4
#define MISO_PIN 3
Adafruit_ADXL345_Unified accel = Adafruit_ADXL345_Unified(SCK_PIN, MISO_PIN, MOSI_PIN, CS_PIN, 12345);
```

**With I2C:**
![Screenshot from 2021-08-03 09-11-43](https://user-images.githubusercontent.com/8755041/128053173-b912f237-88e6-471d-b069-809974576be8.png)

**With SPI:**
![Screenshot from 2021-08-03 09-33-22](https://user-images.githubusercontent.com/8755041/128053200-2044ef0f-a910-4479-8646-02c0a275f8c1.png)
