### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_ADXL345_U.cpp
+++ b/Adafruit_ADXL345_U.cpp
@@ -14,6 +14,13 @@
 
 #include "Adafruit_ADXL345_U.h"
 
+Adafruit_ADXL345_Unified::~Adafruit_ADXL345_Unified() {
+  if (i2c_dev)
+    delete i2c_dev;
+  if (spi_dev)
+    delete spi_dev;
+}
+
 /**************************************************************************/
 /*!
     @brief  Writes one byte to the specified destination register
@@ -146,6 +153,8 @@ Adafruit_ADXL345_Unified::Adafruit_ADXL345_Unified(uint8_t clock, uint8_t miso,
 /**************************************************************************/
 bool Adafruit_ADXL345_Unified::begin(uint8_t i2caddr) {
   if (spi_dev == NULL) {
+    if (i2c_dev)
+      delete i2c_dev;
     i2c_dev = new Adafruit_I2CDevice(i2caddr, &Wire);
     if (!i2c_dev->begin())
       return false;

--- a/Adafruit_ADXL345_U.h
+++ b/Adafruit_ADXL345_U.h
@@ -129,6 +129,7 @@ public:
   Adafruit_ADXL345_Unified(int32_t sensorID = -1);
   Adafruit_ADXL345_Unified(uint8_t clock, uint8_t miso, uint8_t mosi,
                            uint8_t cs, int32_t sensorID = -1);
+  ~Adafruit_ADXL345_Unified();
 
   bool begin(uint8_t addr = ADXL345_DEFAULT_ADDRESS);
   void setRange(range_t range);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit ADXL345
-version=1.3.0
+version=1.3.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Unified driver for the ADXL345 Accelerometer


### PR DESCRIPTION
Tested on Qt PY:

```cpp
#include <Adafruit_ADXL345_U.h>

Adafruit_ADXL345_Unified accel = Adafruit_ADXL345_Unified(12345);

void setup(void) 
{
  Serial.begin(9600);
  while (!Serial);
  
  Serial.println("Accelerometer multi begin() Test");
}

void loop(void) 
{
  if(!accel.begin())
  {
    Serial.println("Ooops, no ADXL345 detected ... Check your wiring!");
    while(1);
  }

  sensors_event_t event; 
  accel.getEvent(&event);
 
  Serial.print("X: "); Serial.print(event.acceleration.x); Serial.print("  ");
  Serial.print("Y: "); Serial.print(event.acceleration.y); Serial.print("  ");
  Serial.print("Z: "); Serial.print(event.acceleration.z); Serial.print("  ");Serial.println("m/s^2 ");
  
  delay(1000);
}
```

![Screenshot from 2021-08-24 14-25-50](https://user-images.githubusercontent.com/8755041/130692291-bcbc42a5-5f2d-4449-bd90-e506dd78b503.png)
