### PR TITLE
Added support for SPI constructor to enable Hardware SPI

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -1,6 +1,6 @@
 name: Arduino Library CI
 
-on: [pull_request, push, repository_dispatch]
+on: [pull_request, push, repository_dispatch,workflow_dispatch]
 
 jobs:
   build:

--- a/Adafruit_ADXL345_U.cpp
+++ b/Adafruit_ADXL345_U.cpp
@@ -146,6 +146,21 @@ Adafruit_ADXL345_Unified::Adafruit_ADXL345_Unified(uint8_t clock, uint8_t miso,
 
 /**************************************************************************/
 /*!
+    @brief  Instantiates a new ADXL345 class in SPI mode
+    @param theSPI The SPI bus to use, defaults to &SPI
+    @param cs The pin number for CS, the SPI Chip Select line
+    @param sensorID A unique ID to use to differentiate the sensor from others
+*/
+/**************************************************************************/
+Adafruit_ADXL345_Unified::Adafruit_ADXL345_Unified(SPIClass *theSPI, uint8_t cs, int32_t sensorID) {
+  _sensorID = sensorID;
+  _range = ADXL345_RANGE_2_G;
+  spi_dev = new Adafruit_SPIDevice(cs, 1000000,
+                                   SPI_BITORDER_MSBFIRST, SPI_MODE1, theSPI);
+}
+
+/**************************************************************************/
+/*!
     @brief  Setups the HW (reads coefficients values, etc.)
     @param i2caddr The I2C address to begin communication with
     @return true: success false: a sensor with the correct ID was not found

--- a/Adafruit_ADXL345_U.h
+++ b/Adafruit_ADXL345_U.h
@@ -129,6 +129,7 @@ public:
   Adafruit_ADXL345_Unified(int32_t sensorID = -1);
   Adafruit_ADXL345_Unified(uint8_t clock, uint8_t miso, uint8_t mosi,
                            uint8_t cs, int32_t sensorID = -1);
+  Adafruit_ADXL345_Unified(SPIClass *theSPI = &SPI, uint8_t cs,int32_t sensorID = -1);
   ~Adafruit_ADXL345_Unified();
 
   bool begin(uint8_t addr = ADXL345_DEFAULT_ADDRESS);


### PR DESCRIPTION
Adafruit_ADXL345_Unified constructors do not support alternatives hardware SPI devices.

The Adafruit_SPIDevice supports selecting the hardware SPI VSPI (pins 19, 18, 5, 23), but this library does not expose that capability.

This library should support using a hardware SPI.

The ESP32, for instance,  has 3 hardware SPIs: SPI, HSPI, and VSPI