### PR TITLE
Update Adafruit_ADXL345_U.cpp

### DIFF
--- a/Adafruit_ADXL345_U.cpp
+++ b/Adafruit_ADXL345_U.cpp
@@ -14,6 +14,10 @@
 
 #include "Adafruit_ADXL345_U.h"
 
+const float MAX_G = 156.9064F;  /* 16g = 156.9064 m/s^2 */
+const float MIN_G = -156.9064F; /* -16g = -156.9064 m/s^2 */
+const float RESOLUTION = 0.03923F; /* 4mg = 0.0392266 m/s^2 */
+
 Adafruit_ADXL345_Unified::~Adafruit_ADXL345_Unified() {
   if (i2c_dev)
     delete i2c_dev;
@@ -30,12 +34,12 @@ Adafruit_ADXL345_Unified::~Adafruit_ADXL345_Unified() {
 /**************************************************************************/
 void Adafruit_ADXL345_Unified::writeRegister(uint8_t reg, uint8_t value) {
   uint8_t buffer[2] = {reg, value};
-  if (i2c_dev) {
-    i2c_dev->write(buffer, 2);
-  } else {
-    spi_dev->write(buffer, 2);
+  auto dev = i2c_dev ? i2c_dev : spi_dev;
+  if (dev) {
+    dev->write(buffer, 2);
   }
 }
+
 
 /**************************************************************************/
 /*!
@@ -45,15 +49,19 @@ void Adafruit_ADXL345_Unified::writeRegister(uint8_t reg, uint8_t value) {
 */
 /**************************************************************************/
 uint8_t Adafruit_ADXL345_Unified::readRegister(uint8_t reg) {
-  uint8_t buffer[1] = {i2c_dev ? reg : (uint8_t)(reg | 0x80)};
+  auto dev = i2c_dev ? i2c_dev : spi_dev;
+  uint8_t buffer[1] = {i2c_dev ? reg : reg | 0x80};
+
   if (i2c_dev) {
-    i2c_dev->write(buffer, 1);
-    i2c_dev->read(buffer, 1);
+    dev->write(buffer, 1);
+    dev->read(buffer, 1);
   } else {
-    spi_dev->write_then_read(buffer, 1, buffer, 1);
+    dev->write_then_read(buffer, 1, buffer, 1);
   }
+
   return buffer[0];
 }
+
 
 /**************************************************************************/
 /*!
@@ -63,15 +71,19 @@ uint8_t Adafruit_ADXL345_Unified::readRegister(uint8_t reg) {
 */
 /**************************************************************************/
 int16_t Adafruit_ADXL345_Unified::read16(uint8_t reg) {
+  auto dev = i2c_dev ? i2c_dev : spi_dev;
   uint8_t buffer[2] = {i2c_dev ? reg : (uint8_t)(reg | 0x80 | 0x40), 0};
+
   if (i2c_dev) {
-    i2c_dev->write(buffer, 1);
-    i2c_dev->read(buffer, 2);
+    dev->write(buffer, 1);
+    dev->read(buffer, 2);
   } else {
-    spi_dev->write_then_read(buffer, 1, buffer, 2);
+    dev->write_then_read(buffer, 1, buffer, 2);
   }
+
   return uint16_t(buffer[1]) << 8 | uint16_t(buffer[0]);
 }
+
 
 /**************************************************************************/
 /*!
@@ -151,17 +163,18 @@ Adafruit_ADXL345_Unified::Adafruit_ADXL345_Unified(uint8_t clock, uint8_t miso,
     @return true: success false: a sensor with the correct ID was not found
 */
 /**************************************************************************/
+bool Adafruit_ADXL345_Unified::beginDevice(Adafruit_BusIO_Register *dev) {
+  if (dev)
+    delete dev;
+
+  dev = spi_dev ? new Adafruit_SPIDevice(SPI_CLOCK_DIV2) : new Adafruit_I2CDevice(i2caddr, &Wire);
+
+  return dev->begin();
+}
+
 bool Adafruit_ADXL345_Unified::begin(uint8_t i2caddr) {
-  if (spi_dev == NULL) {
-    if (i2c_dev)
-      delete i2c_dev;
-    i2c_dev = new Adafruit_I2CDevice(i2caddr, &Wire);
-    if (!i2c_dev->begin())
-      return false;
-  } else {
-    if (!spi_dev->begin())
-      return false;
-  }
+  if (!beginDevice(spi_dev ? spi_dev : i2c_dev))
+    return false;
 
   /* Check connection */
   uint8_t deviceid = getDeviceID();
@@ -248,15 +261,16 @@ bool Adafruit_ADXL345_Unified::getEvent(sensors_event_t *event) {
   event->sensor_id = _sensorID;
   event->type = SENSOR_TYPE_ACCELEROMETER;
   event->timestamp = 0;
-  event->acceleration.x =
-      getX() * ADXL345_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
-  event->acceleration.y =
-      getY() * ADXL345_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
-  event->acceleration.z =
-      getZ() * ADXL345_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
+
+  float scaleFactor = ADXL345_MG2G_MULTIPLIER * SENSORS_GRAVITY_STANDARD;
+  /* Optimizes function readability, reduces computational instructions */
+  event->acceleration.x = getX() * scaleFactor;
+  event->acceleration.y = getY() * scaleFactor;
+  event->acceleration.z = getZ() * scaleFactor;
 
   return true;
 }
+
 
 /**************************************************************************/
 /*!
@@ -264,6 +278,7 @@ bool Adafruit_ADXL345_Unified::getEvent(sensors_event_t *event) {
 /**************************************************************************/
 
 /**
+ * Defined constants for the magic numbers (-156.9064F, 156.9064F, and 0.03923F)
  * @brief Fill a `sensor_t` struct with information about the sensor
  *
  * @param sensor Pointer to a `sensor_t` struct to fill
@@ -279,7 +294,7 @@ void Adafruit_ADXL345_Unified::getSensor(sensor_t *sensor) {
   sensor->sensor_id = _sensorID;
   sensor->type = SENSOR_TYPE_ACCELEROMETER;
   sensor->min_delay = 0;
-  sensor->max_value = -156.9064F; /* -16g = 156.9064 m/s^2  */
-  sensor->min_value = 156.9064F;  /*  16g = 156.9064 m/s^2  */
-  sensor->resolution = 0.03923F;  /*  4mg = 0.0392266 m/s^2 */
+  sensor->max_value = MIN_G;
+  sensor->min_value = MAX_G;
+  sensor->resolution = RESOLUTION;
 }


### PR DESCRIPTION
Minor fixes for slightly fewer calls and code cleanup. My changes don't significantly improve performance but do reduce by a few processing cycles.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

**void Adafruit_ADXL345_Unified::writeRegister**
_Clean up for conciseness_

**uint8_t Adafruit_ADXL345_Unified::readRegister**
_With the aim of reducing the checks for I2C_Dev we first decide which device to use (i2c_dev or spi_dev) and then use this device in both branches of the if-else structure. This way, the device is only selected once at the beginning, and then the same dev pointer is used throughout the function._

**int16_t Adafruit_ADXL345_Unified::read16**
_ This optimization is minor and primarily improves code readability_

**Adafruit_ADXL345_Unified::begin**
_Create a helper function beginDevice() to handle the common logic of beginning a device_

**Adafruit_ADXL345_Unified::getEvent**
_Reduce the number of repeated operations, making the code a bit more efficient._