### PR TITLE
Comment Correction in DataRate

### DIFF
--- a/Adafruit_ADXL345_U.h
+++ b/Adafruit_ADXL345_U.h
@@ -90,23 +90,23 @@
 
 */
 typedef enum {
-  ADXL345_DATARATE_3200_HZ = 0b1111, ///< 1600Hz Bandwidth   140�A IDD
-  ADXL345_DATARATE_1600_HZ = 0b1110, ///<  800Hz Bandwidth    90�A IDD
-  ADXL345_DATARATE_800_HZ = 0b1101,  ///<  400Hz Bandwidth   140�A IDD
-  ADXL345_DATARATE_400_HZ = 0b1100,  ///<  200Hz Bandwidth   140�A IDD
-  ADXL345_DATARATE_200_HZ = 0b1011,  ///<  100Hz Bandwidth   140�A IDD
-  ADXL345_DATARATE_100_HZ = 0b1010,  ///<   50Hz Bandwidth   140�A IDD
-  ADXL345_DATARATE_50_HZ = 0b1001,   ///<   25Hz Bandwidth    90�A IDD
-  ADXL345_DATARATE_25_HZ = 0b1000,   ///< 12.5Hz Bandwidth    60�A IDD
-  ADXL345_DATARATE_12_5_HZ = 0b0111, ///< 6.25Hz Bandwidth    50�A IDD
-  ADXL345_DATARATE_6_25HZ = 0b0110,  ///< 3.13Hz Bandwidth    45�A IDD
-  ADXL345_DATARATE_3_13_HZ = 0b0101, ///< 1.56Hz Bandwidth    40�A IDD
-  ADXL345_DATARATE_1_56_HZ = 0b0100, ///< 0.78Hz Bandwidth    34�A IDD
-  ADXL345_DATARATE_0_78_HZ = 0b0011, ///< 0.39Hz Bandwidth    23�A IDD
-  ADXL345_DATARATE_0_39_HZ = 0b0010, ///< 0.20Hz Bandwidth    23�A IDD
-  ADXL345_DATARATE_0_20_HZ = 0b0001, ///< 0.10Hz Bandwidth    23�A IDD
+  ADXL345_DATARATE_3200_HZ = 0b1111, ///< 3200Hz Bandwidth   140�A IDD
+  ADXL345_DATARATE_1600_HZ = 0b1110, ///< 1600Hz Bandwidth   140�A IDD
+  ADXL345_DATARATE_800_HZ = 0b1101,  ///<  800Hz Bandwidth    90�A IDD
+  ADXL345_DATARATE_400_HZ = 0b1100,  ///<  400Hz Bandwidth   140�A IDD
+  ADXL345_DATARATE_200_HZ = 0b1011,  ///<  200Hz Bandwidth   140�A IDD
+  ADXL345_DATARATE_100_HZ = 0b1010,  ///<  100Hz Bandwidth   140�A IDD
+  ADXL345_DATARATE_50_HZ = 0b1001,   ///<   50Hz Bandwidth   140�A IDD
+  ADXL345_DATARATE_25_HZ = 0b1000,   ///<   25Hz Bandwidth    90�A IDD
+  ADXL345_DATARATE_12_5_HZ = 0b0111, ///< 12.5Hz Bandwidth    60�A IDD
+  ADXL345_DATARATE_6_25HZ = 0b0110,  ///< 6.25Hz Bandwidth    50�A IDD
+  ADXL345_DATARATE_3_13_HZ = 0b0101, ///< 3.13Hz Bandwidth    45�A IDD
+  ADXL345_DATARATE_1_56_HZ = 0b0100, ///< 1.56Hz Bandwidth    40�A IDD
+  ADXL345_DATARATE_0_78_HZ = 0b0011, ///< 0.78Hz Bandwidth    34�A IDD
+  ADXL345_DATARATE_0_39_HZ = 0b0010, ///< 0.39Hz Bandwidth    23�A IDD
+  ADXL345_DATARATE_0_20_HZ = 0b0001, ///< 0.20Hz Bandwidth    23�A IDD
   ADXL345_DATARATE_0_10_HZ =
-      0b0000 ///< 0.05Hz Bandwidth    23�A IDD (default value)
+      0b0000  ///< 0.10Hz Bandwidth    23�A IDD(default value)
 } dataRate_t;
 
 /**


### PR DESCRIPTION
I changed the comments which help devs using vscode to recognize the enums' effect.

However, I changed it based on the example code that prints out the data rate based on the enum returned, therefore, the efficiency might not be correct, hope one should check before merging.

*note: I haven't run tests because I think the change is ignorable and will not break the library.*



